### PR TITLE
Update travis badge for travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AtJSON [![Build Status](https://travis-ci.com/CondeNast-Copilot/atjson.svg?token=EyGr19LqBpbDaJHnY815&branch=latest)](https://travis-ci.com/CondeNast-Copilot/atjson)
+# AtJSON [![Build Status](https://travis-ci.org/CondeNast-Copilot/atjson.svg?branch=latest)](https://travis-ci.org/CondeNast-Copilot/atjson)
 
 AtJSON is a collection of repositories that together make up a fully-realized content format.
 


### PR DESCRIPTION
I believe the original travis hooks may have broken when making the repo public. Updating to use travis-ci.org

- will be "unknown" until merged and tested on the `latest` branch

This PR should show up in travis as well:
https://travis-ci.org/CondeNast-Copilot/atjson/pull_requests
(currently it does not ... investigating)

